### PR TITLE
BLD: Streamlined license generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(
   OUTPUT "${CMAKE_BINARY_DIR}/LICENSE.txt"
   COMMAND "${Python_EXECUTABLE}" cmake/generate_license.py
           "--dist=${CMAKE_BINARY_DIR}/LICENSE.txt"
-  DEPENDS LICENSE.txt cmake/generate_license.py ext/World/LICENSE.txt ${nanobind_VERSION}
+  DEPENDS LICENSE.txt cmake/generate_license.py ext/World/LICENSE.txt wwopy_ext
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Generating ${CMAKE_BINARY_DIR}/LICENSE.txt")
 add_custom_target(wwopy_license ALL DEPENDS "${CMAKE_BINARY_DIR}/LICENSE.txt")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,13 +76,13 @@ install(FILES ${CMAKE_BINARY_DIR}/py.typed ${CMAKE_BINARY_DIR}/wwopy_ext.pyi
         DESTINATION wwopy)
 
 # Merge licenses
-execute_process(
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/LICENSE.txt"
   COMMAND "${Python_EXECUTABLE}" cmake/generate_license.py
           "--dist=${CMAKE_BINARY_DIR}/LICENSE.txt"
+  DEPENDS LICENSE.txt cmake/generate_license.py ext/World/LICENSE.txt ${nanobind_VERSION}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RESULT_VARIABLE result)
-if("${result}")
-  message(FATAL_ERROR "License generation failed.")
-endif()
-install(FILES ${CMAKE_BINARY_DIR}/LICENSE.txt
-        DESTINATION ${SKBUILD_METADATA_DIR}/licenses)
+  COMMENT "Generating ${CMAKE_BINARY_DIR}/LICENSE.txt")
+add_custom_target(wwopy_license ALL DEPENDS "${CMAKE_BINARY_DIR}/LICENSE.txt")
+install(FILES "${CMAKE_BINARY_DIR}/LICENSE.txt"
+        DESTINATION "${SKBUILD_METADATA_DIR}/licenses")

--- a/cmake/generate_license.py
+++ b/cmake/generate_license.py
@@ -2,28 +2,20 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
-import sys
 from pathlib import Path
-from urllib.request import urlopen
-from urllib.response import addinfourl
 
 _project_root = Path(__file__).parents[1]
 
 
 def read_nanobind_license() -> str:
     dist = importlib.metadata.distribution("nanobind")
-    text = dist.read_text("licenses/LICENSE")
+    version = dist.version
+    filename = "LICENSE" if version == "2.0.0" else "licenses/LICENSE"
+    text = dist.read_text(filename)
     if text is None:
-        text = fetch_nanobind_license(dist.version)
+        msg = "nanobind license file is not found."
+        raise Exception(msg)
     return text
-
-
-# fallback
-def fetch_nanobind_license(version: str) -> str:
-    url = f"https://github.com/wjakob/nanobind/raw/refs/tags/v{version}/LICENSE"
-    with urlopen(url) as r:
-        res: addinfourl = r
-        return res.read().decode()
 
 
 def read_license_from_file(filepath: Path) -> str:
@@ -54,5 +46,4 @@ def main(args: list[str] | None = None):
 
 
 if __name__ == "__main__":
-    print("RUN: " + " ".join(sys.argv))  # noqa: T201
     main()


### PR DESCRIPTION
`execute_process`の代わりに`add_custom_command`を使う。

`execute_process`はconfigの度に実行される。
`add_custom_command`はビルド時に必要に応じて実行される。