### PR TITLE
ENH: better type hint.

### DIFF
--- a/pattern_file.nb
+++ b/pattern_file.nb
@@ -1,35 +1,45 @@
 wwopy_ext.cheaptrick:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def cheaptrick(
-        x: NDArray[double] | ArrayLike,
+        x: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fs: int,
-        temporal_positions: NDArray[double] | ArrayLike,
-        f0: NDArray[double] | ArrayLike,
+        temporal_positions: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
+        f0: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         q1: float | None = None,
         f0_floor: float | None = None,
         fft_size: int | None = None,
-    ) -> tuple[NDArray[double], int]:
+    ) -> tuple[ndarray[tuple[int, int], dtype[double]], int]:
         \doc
 
 wwopy_ext.d4c:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def d4c(
-        x: NDArray[double] | ArrayLike,
+        x: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fs: int,
-        temporal_positions: NDArray[double] | ArrayLike,
-        f0: NDArray[double] | ArrayLike,
+        temporal_positions: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
+        f0: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fft_size: int,
         threshold: float | None = None,
-    ) -> NDArray[double]:
+    ) -> ndarray[tuple[int, int], dtype[double]]:
         \doc
 
 wwopy_ext.dio:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def dio(
-        x: NDArray[double] | ArrayLike,
+        x: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fs: int,
         f0_floor: float | None = None,
         f0_ceil: float | None = None,
@@ -37,59 +47,86 @@ wwopy_ext.dio:
         frame_period: float | None = None,
         speed: int | None = None,
         allowed_range: float | None = None,
-    ) -> tuple[NDArray[double], NDArray[double], float]:
+    ) -> tuple[
+        ndarray[tuple[int], dtype[double]], ndarray[tuple[int], dtype[double]], float
+    ]:
         \doc
 
 wwopy_ext.harvest:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def harvest(
-        x: NDArray[double] | ArrayLike,
+        x: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fs: int,
         f0_floor: float | None = None,
         f0_ceil: float | None = None,
         frame_period: float | None = None,
-    ) -> tuple[NDArray[double], NDArray[double], float]:
+    ) -> tuple[
+        ndarray[tuple[int], dtype[double]], ndarray[tuple[int], dtype[double]], float
+    ]:
         \doc
 
 wwopy_ext.stonemask:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def stonemask(
-        x: NDArray[double] | ArrayLike,
+        x: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
         fs: int,
-        temporal_positions: NDArray[double] | ArrayLike,
-        f0: NDArray[double] | ArrayLike,
-    ) -> NDArray[double]:
+        temporal_positions: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
+        f0: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
+    ) -> ndarray[tuple[int], dtype[double]]:
         \doc
 
 wwopy_ext.synthesis:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def synthesis(
-        f0: NDArray[double] | ArrayLike,
-        spectrogram: NDArray[double] | ArrayLike,
-        aperiodicity: NDArray[double] | ArrayLike,
+        f0: ndarray[tuple[int], dtype[double]]
+        | Annotated[ArrayLike, {"dtype": "double", "shape": (None), "writable": False}],
+        spectrogram: ndarray[tuple[int, int], dtype[double]]
+        | Annotated[
+            ArrayLike, {"dtype": "double", "shape": (None, None), "writable": False}
+        ],
+        aperiodicity: ndarray[tuple[int, int], dtype[double]]
+        | Annotated[
+            ArrayLike, {"dtype": "double", "shape": (None, None), "writable": False}
+        ],
         fft_size: int,
         frame_period: float,
         fs: int,
-    ) -> NDArray[double]:
+    ) -> ndarray[tuple[int], dtype[double]]:
         \doc
 
 wwopy_ext.RealtimeSynthesizer.append:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
+    \from typing import Annotated
+    \from numpy import double, dtype, ndarray
+    \from numpy.typing import ArrayLike
     def append(
         self,
-        f0: NDArray[double] | ArrayLike,
-        spectrogram: NDArray[double] | ArrayLike,
-        aperiodicity: NDArray[double] | ArrayLike,
+        f0: ndarray[tuple[int], dtype[double]]
+        | Annotated[
+            ArrayLike, {"dtype": "double", "shape": (None), "writable": False}
+        ],
+        spectrogram: ndarray[tuple[int, int], dtype[double]]
+        | Annotated[
+            ArrayLike, {"dtype": "double", "shape": (None, None), "writable": False}
+        ],
+        aperiodicity: ndarray[tuple[int, int], dtype[double]]
+        | Annotated[
+            ArrayLike, {"dtype": "double", "shape": (None, None), "writable": False}
+        ],
         /,
     ) -> bool:
         \doc
 
 wwopy_ext.RealtimeSynthesizer.synthesis:
-    \from numpy.typing import ArrayLike, NDArray
-    \from numpy import double
-    def synthesis(self) -> NDArray[double] | None:
+    \from numpy import double, dtype, ndarray
+    def synthesis(self) -> ndarray[tuple[int], dtype[double]] | None:
         \doc

--- a/src/cheaptrick_ext.cpp
+++ b/src/cheaptrick_ext.cpp
@@ -107,42 +107,41 @@ void cheeptrick_init(nb::module_& m) {
   m.def(
       "cheaptrick", &cheaptrick, "x"_a, "fs"_a, "temporal_positions"_a, "f0"_a,
       "q1"_a = nb::none(), "f0_floor"_a = nb::none(), "fft_size"_a = nb::none(),
-      nb::call_guard<nb::gil_scoped_release>(),
-      R"(
-        Calculates the spectrogram that consists of spectral envelopes.
-        
-        Parameters
-        ----------
-        x : np.NDArray[np.double]
-            Input signal
-        fs : int
-            Sampling frequency
-        temporal_positions : np.NDArray[np.double]
-            Time axis
-        f0 : np.NDArray[np.double]
-            F0 contour
-        q1 : float, optional
-            Used for the spectral recovery
-            Since The parameter is optimized, you don't need to change the parameter.
-        f0_floor : float, optional
-            Whenever f0 is below this threshold the spectrum will be analyzed as if the frame is unvoiced
-            We strongly recommend not to change this value unless you have enough
-            knowledge of the signal processing in CheapTrick.
-            Used to determine fft_size.
-        fft_size : int, optional
-            FFT size
-            This variable has precedence over f0_floor.
-        
-        Returns
-        -------
-        spectrogram : np.NDArray[np.double]
-            Spectrogram estimated by CheapTrick.
-        fft_size: int
-            Automatically determined fft_size.
-        
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
-        >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0))"
+      nb::call_guard<nb::gil_scoped_release>(), R"(
+      Calculates the spectrogram that consists of spectral envelopes.
+
+      Parameters
+      ----------
+      x : np.ndarray[tuple[int], np.dtype[np.double]]
+          Input signal
+      fs : int
+          Sampling frequency
+      temporal_positions : np.ndarray[tuple[int], np.dtype[np.double]]
+          Time axis
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          F0 contour
+      q1 : float, optional
+          Used for the spectral recovery
+          Since The parameter is optimized, you don't need to change the parameter.
+      f0_floor : float, optional
+          Whenever f0 is below this threshold the spectrum will be analyzed as if the frame is unvoiced
+          We strongly recommend not to change this value unless you have enough
+          knowledge of the signal processing in CheapTrick.
+          Used to determine fft_size.
+      fft_size : int, optional
+          FFT size
+          This variable has precedence over f0_floor.
+
+      Returns
+      -------
+      spectrogram : np.ndarray[tuple[int, int], np.dtype[np.double]]
+          Spectrogram estimated by CheapTrick.
+      fft_size: int
+          Automatically determined fft_size.
+
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
+      >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0))"
   );
 };

--- a/src/d4c_ext.cpp
+++ b/src/d4c_ext.cpp
@@ -75,38 +75,37 @@ auto d4c(
 void d4c_init(nb::module_& m) {
   m.def(
       "d4c", &d4c, "x"_a, "fs"_a, "temporal_positions"_a, "f0"_a, "fft_size"_a,
-      "threshold"_a = nb::none(), nb::call_guard<nb::gil_scoped_release>(),
-      R"(
-        Calculates the aperiodicity.
-        
-        Parameters
-        ----------
-        x : np.NDArray[np.double]
-            Input signal
-        fs : int
-            Sampling frequency
-        temporal_positions : np.NDArray[np.double]
-            Time axis
-        f0 : np.NDArray[np.double]
-            F0 contour
-        fft_size : int
-            FFT size
-            Typically this will be the same as DIO or Harvest.
-        threshold : float, optional
-            It is used to determine the aperiodicity in whole frequency band.
-            D4C identifies whether the frame is voiced segment even if it had an F0.
-            If the estimated value falls below the threshold,
-            the aperiodicity in whole frequency band will set to 1.0.
-        
-        Returns
-        -------
-        aperiodicity : np.NDArray[np.double]
-            Aperiodicity estimated by D4C.
-        
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
-        >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0)
-        >>> aperiodicity = wwopy.d4c(x, fs, temporal_positions, f0, fft_size))"
+      "threshold"_a = nb::none(), nb::call_guard<nb::gil_scoped_release>(), R"(
+      Calculates the aperiodicity.
+
+      Parameters
+      ----------
+      x : np.ndarray[tuple[int], np.dtype[np.double]]
+          Input signal
+      fs : int
+          Sampling frequency
+      temporal_positions : np.ndarray[tuple[int], np.dtype[np.double]]
+          Time axis
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          F0 contour
+      fft_size : int
+          FFT size
+          Typically this will be the same as DIO or Harvest.
+      threshold : float, optional
+          It is used to determine the aperiodicity in whole frequency band.
+          D4C identifies whether the frame is voiced segment even if it had an F0.
+          If the estimated value falls below the threshold,
+          the aperiodicity in whole frequency band will set to 1.0.
+
+      Returns
+      -------
+      np.ndarray[tuple[int, int], np.dtype[np.double]]
+          Aperiodicity estimated by D4C.
+
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
+      >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0)
+      >>> aperiodicity = wwopy.d4c(x, fs, temporal_positions, f0, fft_size))"
   );
 }

--- a/src/dio_ext.cpp
+++ b/src/dio_ext.cpp
@@ -100,36 +100,36 @@ void dio_init(nb::module_& m) {
       "frame_period"_a = nb::none(), "speed"_a = nb::none(),
       "allowed_range"_a = nb::none(), nb::call_guard<nb::gil_scoped_release>(),
       R"(
-        Calculates the F0 contour.
-        
-        Parameters
-        ----------
-        x : np.NDArray[np.double]
-            Input signal
-        fs : int
-            Sampling frequency
-        f0_floor : float, optional
-        f0_ceil : float, optional
-        channels_in_octave : float, optional
-        frame_period : float, optional
-            Frame shift
-        speed : int, optional
-            Valuable speed represents the ratio for downsampling.
-            The signal is downsampled to fs / speed Hz.
-        allowed_range : float, optional
-            Threshold used for fixing the F0 contour.
-        
-        Returns
-        -------
-        temporal_positions : np.NDArray[np.double]
-            Time axis estimated by DIO.
-        f0 : np.NDArray[np.double]
-            F0 contour estimated by DIO.
-        frame_period : float
-            Automatically determined frame_period.
+      Calculates the F0 contour.
+      
+      Parameters
+      ----------
+      x : np.ndarray[tuple[int], np.dtype[np.double]]
+          Input signal
+      fs : int
+          Sampling frequency
+      f0_floor : float, optional
+      f0_ceil : float, optional
+      channels_in_octave : float, optional
+      frame_period : float, optional
+          Frame shift
+      speed : int, optional
+          Valuable speed represents the ratio for downsampling.
+          The signal is downsampled to fs / speed Hz.
+      allowed_range : float, optional
+          Threshold used for fixing the F0 contour.
+      
+      Returns
+      -------
+      temporal_positions : np.ndarray[tuple[int], np.dtype[np.double]]
+          Time axis estimated by DIO.
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          F0 contour estimated by DIO.
+      frame_period : float
+          Automatically determined frame_period.
 
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs))"
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs))"
   );
 }

--- a/src/harvest_ext.cpp
+++ b/src/harvest_ext.cpp
@@ -80,32 +80,31 @@ void harvest_init(nb::module_& m) {
   m.def(
       "harvest", &harvest, "x"_a, "fs"_a, "f0_floor"_a = nb::none(),
       "f0_ceil"_a = nb::none(), "frame_period"_a = nb::none(),
-      nb::call_guard<nb::gil_scoped_release>(),
-      R"(
-        Calculates the F0 contour.
-        
-        Parameters
-        ----------
-        x : np.NDArray[np.double]
-            Input signal
-        fs : int
-            Sampling frequency
-        f0_floor : float, optional
-        f0_ceil : float, optional
-        frame_period : float, optional
-            Frame shift
-        
-        Returns
-        -------
-        temporal_positions : np.NDArray[np.double]
-            Time axis estimated by Harvest.
-        f0 : np.NDArray[np.double]
-            F0 contour estimated by Harvest.
-        frame_period : float
-            Automatically determined frame_period.
+      nb::call_guard<nb::gil_scoped_release>(), R"(
+      Calculates the F0 contour.
 
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs))"
+      Parameters
+      ----------
+      x : np.ndarray[tuple[int], np.dtype[np.double]]
+          Input signal
+      fs : int
+          Sampling frequency
+      f0_floor : float, optional
+      f0_ceil : float, optional
+      frame_period : float, optional
+          Frame shift
+
+      Returns
+      -------
+      temporal_positions : np.ndarray[tuple[int], np.dtype[np.double]]
+          Time axis estimated by Harvest.
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          F0 contour estimated by Harvest.
+      frame_period : float
+          Automatically determined frame_period.
+
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.harvest(x, fs))"
   );
 }

--- a/src/stonemask_ext.cpp
+++ b/src/stonemask_ext.cpp
@@ -57,29 +57,28 @@ auto stonemask(
 void stonemask_init(nb::module_& m) {
   m.def(
       "stonemask", &stonemask, "x"_a, "fs"_a, "temporal_positions"_a, "f0"_a,
-      nb::call_guard<nb::gil_scoped_release>(),
-      R"(
-        Refines the estimated F0 by Dio()
-        
-        Parameters
-        ----------
-        x : np.NDArray[np.double]
-            Input signal
-        fs : int
-            Sampling frequency
-        temporal_positions : np.NDArray[np.double]
-            Time axis by dio()
-        f0 : np.NDArray[np.double]
-            F0 contour by dio()
-        
-        Returns
-        -------
-        refined_f0 : np.NDArray[np.double]
-            Refined F0.
-        
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs)
-        >>> refined_f0 = wwopy.stonemask(x, fs, temporal_positions, f0))"
+      nb::call_guard<nb::gil_scoped_release>(), R"(
+      Refines the estimated F0 by Dio()
+
+      Parameters
+      ----------
+      x : np.ndarray[tuple[int], np.dtype[np.double]]
+          Input signal
+      fs : int
+          Sampling frequency
+      temporal_positions : np.ndarray[tuple[int], np.dtype[np.double]]
+          Time axis by dio()
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          F0 contour by dio()
+
+      Returns
+      -------
+      np.ndarray[tuple[int], np.dtype[np.double]]
+          Refined F0.
+
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs)
+      >>> refined_f0 = wwopy.stonemask(x, fs, temporal_positions, f0))"
   );
 }

--- a/src/synthesis_ext.cpp
+++ b/src/synthesis_ext.cpp
@@ -83,36 +83,35 @@ void synthesis_init(nb::module_& m) {
   m.def(
       "synthesis", &synthesis, "f0"_a, "spectrogram"_a, "aperiodicity"_a,
       "fft_size"_a, "frame_period"_a, "fs"_a,
-      nb::call_guard<nb::gil_scoped_release>(),
-      R"(
-        Synthesize the voice based on f0, spectrogram and aperiodicity.
-        
-        Parameters
-        ----------
-        f0 : np.NDArray[np.double]
-            f0 contour
-        spectrogram : np.NDArray[np.double]
-            Spectrogram
-        aperiodicity : np.NDArray[np.double]
-            Aperiodicity spectrogram
-        fft_size : int
-            FFT size
-        frame_period : float
-            Temporal period used for the analysis
-        fs : int
-            Sampling frequency
-        
-        Returns
-        -------
-        y : np.NDArray[np.double]
-            Calculated speech.
-        
-        Examples
-        --------
-        >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs)
-        >>> refined_f0 = wwopy.stonemask(x, fs, temporal_positions, f0)
-        >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, refined_f0)
-        >>> aperiodicity = wwopy.d4c(x, fs, temporal_positions, refined_f0, fft_size)
-        >>> y = wwopy.synthesis(refined_f0, spectrogram, aperiodicity, fft_size, frame_period, fs))"
+      nb::call_guard<nb::gil_scoped_release>(), R"(
+      Synthesize the voice based on f0, spectrogram and aperiodicity.
+
+      Parameters
+      ----------
+      f0 : np.ndarray[tuple[int], np.dtype[np.double]]
+          f0 contour
+      spectrogram : np.ndarray[tuple[int, int], np.dtype[np.double]]
+          Spectrogram
+      aperiodicity : np.ndarray[tuple[int, int], np.dtype[np.double]]
+          Aperiodicity spectrogram
+      fft_size : int
+          FFT size
+      frame_period : float
+          Temporal period used for the analysis
+      fs : int
+          Sampling frequency
+
+      Returns
+      -------
+      np.ndarray[tuple[int], np.dtype[np.double]]
+          Calculated speech.
+
+      Examples
+      --------
+      >>> temporal_positions, f0, frame_period = wwopy.dio(x, fs)
+      >>> refined_f0 = wwopy.stonemask(x, fs, temporal_positions, f0)
+      >>> spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, refined_f0)
+      >>> aperiodicity = wwopy.d4c(x, fs, temporal_positions, refined_f0, fft_size)
+      >>> y = wwopy.synthesis(refined_f0, spectrogram, aperiodicity, fft_size, frame_period, fs))"
   );
 }

--- a/src/synthesisrealtime_ext.cpp
+++ b/src/synthesisrealtime_ext.cpp
@@ -174,8 +174,7 @@ void synthesisrealtime_init(nb::module_& m) {
   RealtimeSynthesizer
 
   Voice synthesis based on f0, spectrogram and aperiodicity.
-  This is an implementation for real-time applications.
-  )")
+  This is an implementation for real-time applications.)")
       .def(
           nb::init<const int, const double, const int, const int, const int>(),
           "fs"_a, "frame_period"_a, "fft_size"_a, "buffer_size"_a,
@@ -193,8 +192,7 @@ void synthesisrealtime_init(nb::module_& m) {
           buffer_size : int
               Buffer size (sample)
           number_of_pointers : int
-              The number of elements in the ring buffer
-          )"
+              The number of elements in the ring buffer)"
       )
       .def(
           "append", &RealtimeSynthesizer::append,
@@ -204,23 +202,20 @@ void synthesisrealtime_init(nb::module_& m) {
 
           Parameters
           ----------
-          f0 : np.NDArray[np.double]
+          f0 : np.ndarray[tuple[int], np.dtype[np.double]]
               F0 contour with length of f0_length
-          spectrogram : np.NDArray[np.double]
+          spectrogram : np.ndarray[tuple[int, int], np.dtype[np.double]]
               Spectrogram
-          aperiodicity : np.NDArray[np.double]
+          aperiodicity : np.ndarray[tuple[int, int], np.dtype[np.double]]
               Aperiodicity
 
           Returns
           -------
           bool
               True if added successfully.
-              Retrun True if the parameter is an empty array.
-          )"
+              Retrun True if the parameter is an empty array.)"
       )
-      .def(
-          "locked", &RealtimeSynthesizer::locked,
-          R"(
+      .def("locked", &RealtimeSynthesizer::locked, R"(
           Checks whether the synthesizer is locked or not.
           "Lock" is defined as the situation that the ring buffer cannot add parameters and cannot synthesize the waveform.
           It will be caused when the duration calculated by the number of added frames is below 1 / F0 + buffer_size / fs.
@@ -228,19 +223,15 @@ void synthesisrealtime_init(nb::module_& m) {
 
           Returns
           -------
-          bool
-          )"
-      )
+          bool)")
       .def(
           "synthesis", &RealtimeSynthesizer::synthesis,
-          nb::call_guard<nb::gil_scoped_release>(),
-          R"(
+          nb::call_guard<nb::gil_scoped_release>(), R"(
           Generates speech with length of buffer_size sample.
 
           Returns
           -------
-          np.NDArray[np.double] or None
-          )"
+          np.ndarray[tuple[int], np.dtype[np.double]] or None)"
       )
       .def(
           "refresh", &RealtimeSynthesizer::refresh,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 import wave
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -13,14 +12,12 @@ import wwopy
 if sys.version_info >= (3, 11):
     from typing import assert_never
 
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 _TEST_FILE = Path(__file__).parents[1] / "ext/World/test/vaiueo2d.wav"
 
 
 @pytest.fixture
-def test_wave() -> tuple[npt.NDArray[np.double], int]:
+def test_wave() -> tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]:
     with wave.open(str(_TEST_FILE), "rb") as f:
         f: wave.Wave_read
         nchannels = f.getnchannels()
@@ -52,17 +49,17 @@ def test_wave() -> tuple[npt.NDArray[np.double], int]:
 
 @pytest.fixture
 def dio_result(
-    test_wave: tuple[npt.NDArray[np.double], int],
-) -> tuple[npt.NDArray[np.double], npt.NDArray[np.double], float]:
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+) -> tuple[np.ndarray[tuple[int], np.dtype[np.double]], float]:
     x, fs = test_wave
     return wwopy.dio(x, fs)
 
 
 @pytest.fixture
 def cheaptrick_result(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
-) -> tuple[npt.NDArray[np.double], int]:
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
+) -> tuple[np.ndarray[tuple[int, int], np.dtype[np.double]], int]:
     x, fs = test_wave
     temporal_positions, f0, frame_period = dio_result
     return wwopy.cheaptrick(x, fs, temporal_positions, f0)
@@ -70,10 +67,10 @@ def cheaptrick_result(
 
 @pytest.fixture
 def d4c_result(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
-    cheaptrick_result: tuple[npt.NDArray[np.double], int],
-) -> npt.NDArray[np.double]:
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
+    cheaptrick_result: tuple[np.ndarray[tuple[int, int], np.dtype[np.double]], int],
+) -> np.ndarray[tuple[int, int]]:
     x, fs = test_wave
     temporal_positions, f0, frame_period = dio_result
     spectrogram, fft_size = cheaptrick_result

--- a/test/test_cheaptrick.py
+++ b/test/test_cheaptrick.py
@@ -31,8 +31,8 @@ def test_fft_size(
 
 
 def test_get_fft_size_from_f0_floor(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
 ):
     x, fs = test_wave
     temporal_positions, f0, frame_period = dio_result

--- a/test/test_cheaptrick.py
+++ b/test/test_cheaptrick.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pytest
 
 import wwopy
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 
 def test_empty():
@@ -23,8 +18,8 @@ def test_empty():
 
 
 def test_fft_size(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
 ):
     x, fs = test_wave
     fft_size = 4096
@@ -36,8 +31,8 @@ def test_fft_size(
 
 
 def test_warning(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
 ):
     x, fs = test_wave
     temporal_positions, f0, frame_period = dio_result

--- a/test/test_synthesisrealtime.py
+++ b/test/test_synthesisrealtime.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 
 import wwopy
 
-if TYPE_CHECKING:
-    import numpy.typing as npt
-
 
 def test_multi_append(
-    test_wave: tuple[npt.NDArray[np.double], int],
-    dio_result: tuple[npt.NDArray[np.double], npt.NDArray[np.double], float],
-    cheaptrick_result: tuple[npt.NDArray[np.double], int],
-    d4c_result: npt.NDArray[np.double],
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+    dio_result: tuple[np.ndarray[tuple[int], np.dtype[np.double]], float],
+    cheaptrick_result: tuple[np.ndarray[tuple[int, int], np.dtype[np.double]], int],
+    d4c_result: np.ndarray[tuple[int, int]],
 ):
     x, fs = test_wave
     temporal_positions, f0, frame_period = dio_result

--- a/test/test_wwopy.py
+++ b/test/test_wwopy.py
@@ -1,40 +1,35 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
-
-if TYPE_CHECKING:
-    import numpy.typing as npt
 
 import wwopy
 
 
-def test_cheaptrick(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_cheaptrick(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
     wwopy.cheaptrick(x, fs, temporal_positions, f0)
 
 
-def test_d4c(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_d4c(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
     spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0)
     wwopy.d4c(x, fs, temporal_positions, f0, fft_size)
 
 
-def test_dio(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_dio(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     wwopy.dio(x, fs)
 
 
-def test_stonemask(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_stonemask(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     temporal_positions, f0, frame_period = wwopy.dio(x, fs)
     wwopy.stonemask(x, fs, temporal_positions, f0)
 
 
-def test_synthesis(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_synthesis(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
     spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0)
@@ -42,12 +37,14 @@ def test_synthesis(test_wave: tuple[npt.NDArray[np.double], int]):
     wwopy.synthesis(f0, spectrogram, aperiodicity, fft_size, frame_period, fs)
 
 
-def test_harvest(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_harvest(test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int]):
     x, fs = test_wave
     wwopy.harvest(x, fs)
 
 
-def test_realtimesynthesizer(test_wave: tuple[npt.NDArray[np.double], int]):
+def test_realtimesynthesizer(
+    test_wave: tuple[np.ndarray[tuple[int], np.dtype[np.double]], int],
+):
     x, fs = test_wave
     temporal_positions, f0, frame_period = wwopy.harvest(x, fs)
     spectrogram, fft_size = wwopy.cheaptrick(x, fs, temporal_positions, f0)


### PR DESCRIPTION
- `npt.NDArray[np.double]` to `np.ndarray[tuple[int], np.dtype[np.double]]`.
- Added `Annotated` to `ArrayLike`.
note: I couldn't find any documentation on how to write `Annotated`. I might be wrong.