### PR TITLE
ENH: Generate licenses only if necessary.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.30)
+cmake_minimum_required(VERSION 3.15...3.31)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 if(NOT "${SKBUILD}")
@@ -89,15 +89,23 @@ if("${SKBUILD_STATE}" STREQUAL "editable")
 endif()
 
 # Merge licenses
-add_custom_command(OUTPUT always_rebuild COMMAND "${CMAKE_COMMAND}" -E echo)
-set_source_files_properties(always_rebuild PROPERTIES SYMBOLIC ON)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" cmake/get_nanobind_license_path.py
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  OUTPUT_VARIABLE nanobind_license_path
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ENCODING UTF-8)
+
 add_custom_command(
   OUTPUT "${CMAKE_BINARY_DIR}/LICENSE.txt"
-  COMMAND "${Python_EXECUTABLE}" cmake/generate_license.py
-          "--dist=${CMAKE_BINARY_DIR}/LICENSE.txt"
-  DEPENDS always_rebuild
+  COMMAND
+    "${Python_EXECUTABLE}" cmake/generate_license.py nanobind
+    "${nanobind_license_path}" WORLD ext/World/LICENSE.txt
+    "--dist=${CMAKE_BINARY_DIR}/LICENSE.txt"
+  DEPENDS "${nanobind_license_path}" ext/World/LICENSE.txt
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   COMMENT "Generating ${CMAKE_BINARY_DIR}/LICENSE.txt")
+
 add_custom_target(wwopy_license ALL DEPENDS "${CMAKE_BINARY_DIR}/LICENSE.txt")
 install(FILES "${CMAKE_BINARY_DIR}/LICENSE.txt"
         DESTINATION "${SKBUILD_METADATA_DIR}/licenses")

--- a/cmake/generate_license.py
+++ b/cmake/generate_license.py
@@ -1,49 +1,44 @@
 from __future__ import annotations
 
 import argparse
-import importlib.metadata
+from collections.abc import Iterable
 from pathlib import Path
 
 _project_root = Path(__file__).parents[1]
-
-
-def read_nanobind_license() -> str:
-    dist = importlib.metadata.distribution("nanobind")
-    version = dist.version
-    # NOTE: Use packaging when requirements increase
-    filename = "LICENSE" if version == "2.0.0" else "licenses/LICENSE"
-    text = dist.read_text(filename)
-    if text is None:
-        msg = "nanobind license file is not found."
-        raise Exception(msg)
-    return text
 
 
 def read_license_from_file(filepath: Path) -> str:
     return filepath.read_text("utf-8")
 
 
-def write_license(dist: Path, licenses: list[tuple[str, str]]):
+def write_license(dist: Path, licenses: Iterable[tuple[str, str]]):
     delimiter = "\n" + "=" * 80 + "\n\n"
     with dist.open(mode="wt", encoding="utf-8", newline="\n") as f:
-        f.write(read_license_from_file(_project_root / "LICENSE.txt") + "\n\n")
-        f.write("ThirdPartyLicenses")
-        for name, text in licenses:
+        project_license = (_project_root / "LICENSE.txt").read_text("utf-8")
+        f.write(project_license)
+        f.write("\n\nThirdPartyLicenses")
+        for name, license_path in licenses:
             f.write(delimiter)
             f.write(f"{name}\n")
             f.write("-" * len(name) + "\n\n")
-            f.write(text)
+            try:
+                license_text = Path(license_path).read_text("utf-8")
+            except OSError as e:
+                msg = f"Licene Error: {name}"
+                raise Exception(msg) from e
+            f.write(license_text)
 
 
 def main(args: list[str] | None = None):
     parser = argparse.ArgumentParser()
+    parser.add_argument("files", type=str, nargs="+")
     parser.add_argument("--dist", type=Path, required=True)
     parsed_arg = parser.parse_args(args)
-    licenses = [
-        ("WORLD", read_license_from_file(_project_root / "ext/World/LICENSE.txt")),
-        ("nanobind", read_nanobind_license()),
-    ]
-    write_license(parsed_arg.dist, licenses)
+    files: list[str] = parsed_arg.files
+    if len(files) % 2 == 1:
+        msg = "argment is wrong"
+        raise Exception(msg)
+    write_license(parsed_arg.dist, zip(files[0::2], files[1::2]))
 
 
 if __name__ == "__main__":

--- a/cmake/get_nanobind_license_path.py
+++ b/cmake/get_nanobind_license_path.py
@@ -1,0 +1,18 @@
+import sys
+from importlib.metadata import distribution
+
+if __name__ == "__main__":
+    sys.stdout.reconfigure(encoding="utf-8")
+    dist = distribution("nanobind")
+    version = dist.version
+    # NOTE: Use packaging when requirements increase
+    filename = "LICENSE" if version == "2.0.0" else "licenses/LICENSE"
+    target = None
+    for file in dist.files:
+        if file.match(f"nanobind-*.dist-info/{filename}"):
+            target = file
+            break
+    if target is None:
+        msg = "nanobind license file is not found."
+        raise Exception(msg)
+    print(target.locate())  # noqa: T201

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-  "nanobind>=2, <3",
+  "nanobind~=2.0",
   "scikit-build-core>=0.10",
-  "setuptools_scm>=8, <9",
+  "setuptools_scm~=8.0",
   "typing_extensions>=3.10, <5; python_version<'3.11'",
 ]
 build-backend = "scikit_build_core.build"
@@ -39,7 +39,7 @@ classifiers = [
 dependencies = ["numpy"]
 
 [project.optional-dependencies]
-dev = ["clang-format==19.*", "clang-tidy==19.*", "cmake-format", "ruff"]
+dev = ["clang-format~=19.0", "clang-tidy~=19.0", "cmake-format", "ruff"]
 test = ["pytest"]
 
 [tool.scikit-build]
@@ -64,7 +64,7 @@ sdist.exclude = [
   "ext/World/makefile",
   "ext/World/styleguide.txt",
 ]
-wheel.license-files = []
+wheel.license-files = ["LICENSE.txt"]
 
 [tool.setuptools_scm]
 version_file = "src/wwopy/_version.py"


### PR DESCRIPTION
Get the license file path for nanobind.
Add it to your dependencies so changes can be detected.

And fix metadata.