### PR TITLE
FIX: Use `std::numeric_limits`

### DIFF
--- a/src/cheaptrick_ext.cpp
+++ b/src/cheaptrick_ext.cpp
@@ -9,8 +9,8 @@ SPDX-License-Identifier: BSD-2-Clause
 #include <nanobind/stl/optional.h>
 #include <world/cheaptrick.h>
 
-#include <climits>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -64,7 +64,8 @@ auto cheaptrick(
     if (*f0_floor <= 0.0) {
       throw std::invalid_argument("f0_floor must be non-negative.");
     }
-    if (*f0_floor < GetF0FloorForCheapTrick(fs, INT_MAX)) {
+    if (*f0_floor <
+        GetF0FloorForCheapTrick(fs, std::numeric_limits<int>::max())) {
       throw std::invalid_argument("Determine fft_size is invalid.");
     }
     option.f0_floor = *f0_floor;
@@ -112,7 +113,8 @@ auto get_fft_size_from_f0_floor(
     if (*f0_floor <= 0.0) {
       throw std::invalid_argument("f0_floor must be non-negative.");
     }
-    if (*f0_floor < GetF0FloorForCheapTrick(fs, INT_MAX)) {
+    if (*f0_floor <
+        GetF0FloorForCheapTrick(fs, std::numeric_limits<int>::max())) {
       throw std::invalid_argument("Determine fft_size is invalid.");
     }
     option.f0_floor = *f0_floor;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -7,8 +7,8 @@ SPDX-License-Identifier: BSD-2-Clause
 
 #include <nanobind/ndarray.h>
 
-#include <climits>
 #include <cstddef>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -22,9 +22,10 @@ auto util::make_empty_ndarray()
 }
 
 void util::validate_x_lenth(size_t x_lenth) {
-  if (x_lenth > INT_MAX) {
+  if (x_lenth > std::numeric_limits<int>::max()) {
     std::basic_ostringstream<char> s;
-    s << "length of x must be less than or equal to " << INT_MAX << ".";
+    s << "length of x must be less than or equal to "
+      << std::numeric_limits<int>::max() << ".";
     throw std::range_error(s.str());
   }
 }


### PR DESCRIPTION
Use `std::numeric_limits<int>::max()` instead of `INT_MAX`.
Macros should be avoided.