### PR TITLE
MNT: update cibuildwheel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         if: runner.os == 'macOS' && runner.arch == 'ARM64'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.1.4
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,10 @@ _version = "{version}"
 [tool.cibuildwheel]
 skip = [
   "pp38-*",  # Not work
-  "pp31{1,2,3}-*", # Numpy does not support
+  "pp31{2...9}-*", # Numpy does not support
 ]
 archs = "auto64"
 enable = ["pypy"]
-
-build-frontend = "build"
 
 test-command = "pytest {project}/tests"
 test-extras = ["test"]


### PR DESCRIPTION
- fix #36

The default build-frontend is now build.
pypy, which has reached end of life, is not included.
(However, it remains in the skip element.)